### PR TITLE
Fix Mockgen dead link

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@
   - [gotests](https://github.com/cweill/gotests)
   - [gopkgs v2](https://github.com/uudashr/gopkgs/tree/master/v2)
 - Terminal Go tools
-  - [mockgen](https://github.com/golang/mock/mockgen) to generate mocks
+  - [mockgen](https://github.com/golang/mock) to generate mocks
   - [mockery](https://github.com/vektra/mockery) to generate mocks for testify/mock
 - Cross platform
   - Easily bind mount your SSH keys to use with **git**


### PR DESCRIPTION
Change to the correct one (https://github.com/golang/mock)