### PR TITLE
fix vscode debug failed to launched

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -60,7 +60,7 @@
         "go.lintOnSave": "package",
         "editor.formatOnSave": true,
         "go.toolsEnvVars": {
-            "CGO_ENABLED": 0
+            "CGO_ENABLED": "0"
         },
         "go.testEnvVars": {
             "": "",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -75,3 +75,4 @@
         "go.coverOnTestPackage": true
     }
 }
+


### PR DESCRIPTION
When I pressed F5 to start the debug, I got this error `Failed to launch: invalid debug configuration - cannot unmarshal bool into "env" of type string`

I changed `CGO_ENABLED` value from `0` to `"0"` then it fixed the issue.
 [https://github.com/golang/vscode-go/issues/2206](https://github.com/golang/vscode-go/issues/2206)